### PR TITLE
使用した化粧品の登録機能の作成

### DIFF
--- a/app/controllers/mycosmetics_controller.rb
+++ b/app/controllers/mycosmetics_controller.rb
@@ -1,0 +1,24 @@
+class MycosmeticsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @cosmetic = Cosmetic.find(params[:cosmetic_id]) # cosmetic_idを使ってCosmeticを取得
+    @mycosmetic = Mycosmetic.new # 新しいMycosmeticのインスタンスを生成
+  end
+
+  def create
+    @cosmetic = Cosmetic.find(params[:mycosmetic][:cosmetic_id]) # フォームから送信されたcosmetic_idを使ってCosmeticを取得
+    @mycosmetic = current_user.mycosmetics.build(mycosmetic_params) # Mycosmeticをユーザーに紐付けてインスタンス生成
+    if @mycosmetic.save
+      redirect_to cosmetics_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def mycosmetic_params
+    params.require(:mycosmetic).permit(:usage_situation, :starting_date, :problem, :memo, :cosmetic_id).merge(user_id: params[:user_id])
+  end
+end

--- a/app/helpers/mycosmetics_helper.rb
+++ b/app/helpers/mycosmetics_helper.rb
@@ -1,0 +1,2 @@
+module MycosmeticsHelper
+end

--- a/app/models/mycosmetic.rb
+++ b/app/models/mycosmetic.rb
@@ -1,4 +1,8 @@
 class Mycosmetic < ApplicationRecord
+  validates :cosmetic_id, uniqueness: true
+
   belongs_to :user
   belongs_to :cosmetic
+
+  enum :problem, { good: 0, normal: 1,  bad: 2 }
 end

--- a/app/views/cosmetics/_cosmetic.html.erb
+++ b/app/views/cosmetics/_cosmetic.html.erb
@@ -15,7 +15,9 @@
         <%= cosmetic.amount %>
       </p>
       <div class="card-actions justify-end">
-        <button class="btn bg-beige btn-outline">登録</button>
+        <button class="btn bg-beige btn-outline">
+          <%= link_to "登録", new_mycosmetic_path(cosmetic_id: cosmetic.id) %>
+        </button>
         <button class="btn outline">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/views/mycosmetics/_mycosme_form.html.erb
+++ b/app/views/mycosmetics/_mycosme_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: mycosmetic, url: mycosmetics_path do |f| %>
+  <div class>
+    <%= f.hidden_field :cosmetic_id, value: @cosmetic.id %>
+    <div class="input input-bordered flex items-center gap-2 mb-4">
+      <%= f.label :usage_situation, "現在の利用状況" %>
+      <%= f.select :usage_situation, [['利用している',true],['利用していない',false]] %>
+    </div>
+    <div class="input input-bordered flex items-center gap-2 mb-4">
+      <%= f.label :starting_date, "利用開始日" %>
+      <%= f.date_field :starting_date %>
+    </div>
+    <div class="input input-bordered flex items-center gap-2 mb-4">
+      <%= f.label :problem, "利用時の問題" %>
+      <%= f.select :problem, [["良い", "good"], ["普通", "normal"], ["悪い", "bad"]] %>
+    </div>
+    <div class="input input-bordered flex flex-col items-center gap-2 mb-4 size-auto">
+      <%= f.label :memo, "メモ" %>
+      <%= f.text_area :memo , class: "w-full h-32 resize-y"%>
+    </div>
+  </div>
+  <div class="flex flex-col items-center justify-center">
+    <div class="btn btn-wide bg-beige btn-outline">
+      <%= f.submit "登録" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/mycosmetics/new.html.erb
+++ b/app/views/mycosmetics/new.html.erb
@@ -1,0 +1,22 @@
+<div class="bg-cream">
+  <div class="flex-col card p-10">
+    <h1 class="card-title p-3 justify-center">登録内容</h1>
+    <div class="bg-base-100 m-4 items-center">
+      <div class="card-body flex items-center">
+        <%= image_tag @cosmetic.image, class: "size-48 p-3" %>
+        <div class="ml-4">
+          <h2 class="card-title">
+            <%= @cosmetic.product_name %>
+          </h2>
+          <p>
+            <%= @cosmetic.category.name %>
+          </p>
+          <p>
+            <%= @cosmetic.brand.name %>
+          </p>
+        </div>
+      </div>
+    </div>
+    <%= render 'mycosme_form', mycosmetic: @mycosmetic %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :cosmetics, only: %i[index show]
+  resources :mycosmetics, only: %i[new create]
 end

--- a/test/controllers/mycosmetics_controller_test.rb
+++ b/test/controllers/mycosmetics_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MycosmeticsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 関連issue
Closes #23 

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- 使用した化粧品の登録機能の作成

## 実装内容
- Mycosmeticsコントローラを作成
- Mycosmeticsコントローラにnew,createアクションを追加
- ルーティングにnew,createアクションを追加
- mycosmetics/new.html.erbを作成
  - 化粧品の画像、商品名、ブランド名、カテゴリーを表示
  - _mycosme_formを呼び出している
- _mycosme_form.html.erbを作成
  - 現在の利用状況（利用しているか、利用していないかの２択）のフォームの作成
  - 利用開始日（日付）のフォームの作成
  - 利用時の問題（良い、普通、悪いの3択）の作成
  - メモのフォームを作成
- ストロングパラメータを設定

## 備考
登録に成功した場合、使用した化粧品一覧（マイコスメ一覧）に遷移するようになっていたが、まだ一覧ページを作成していないため、化粧品一覧ページに遷移するようになっている。
失敗した時には、mycosmetics/new.html.erbにレンダーする