### PR TITLE
フラッシュメッセージの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  add_flash_types :success, :danger
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/mycosmetics_controller.rb
+++ b/app/controllers/mycosmetics_controller.rb
@@ -10,8 +10,9 @@ class MycosmeticsController < ApplicationController
     @cosmetic = Cosmetic.find(params[:mycosmetic][:cosmetic_id]) # フォームから送信されたcosmetic_idを使ってCosmeticを取得
     @mycosmetic = current_user.mycosmetics.build(mycosmetic_params) # Mycosmeticをユーザーに紐付けてインスタンス生成
     if @mycosmetic.save
-      redirect_to mycosmetics_path
+      redirect_to mycosmetics_path, success: "マイコスメに登録できました"
     else
+      flash.now[danger] = "すでに登録されています"
       render :new, status: :unprocessable_entity
     end
   end
@@ -29,8 +30,9 @@ class MycosmeticsController < ApplicationController
     @mycosmetic = current_user.mycosmetics.find(params[:id])
     @cosmetic = Cosmetic.find(@mycosmetic.cosmetic_id)
     if @mycosmetic.update(mycosmetic_params)
-      redirect_to mycosmetics_path
+      redirect_to mycosmetics_path, success: "登録内容を更新しました"
     else
+      flash.now[danger] = "登録内容の更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -38,7 +40,7 @@ class MycosmeticsController < ApplicationController
   def destroy
     @mycosmetic = current_user.mycosmetics.find(params[:id])
     @mycosmetic.destroy!
-    redirect_to mycosmetics_path
+    redirect_to mycosmetics_path, success: "マイコスメから削除しました"
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,8 +14,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.new(sign_up_params)
     if @user.save
       sign_in(@user) # ユーザーをサインインさせる
-      redirect_to cosmetics_path # コスメ一覧ページにリダイレクト
+      redirect_to cosmetics_path, success: t("defaults.flash_message.created", item: User.model_name.human) # コスメ一覧ページにリダイレクト
     else
+      flash.now[:danger] = t("defaults.flash_message.not_created", item: User.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -29,8 +30,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def update
     @user = current_user
     if @user.update(account_update_params)
-      redirect_to user_path(@user)
+      redirect_to user_path(@user), success: t("defaults.flash_message.updated", item: User.model_name.human)
     else
+      flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,9 +23,8 @@
       <% else %>
         <%= render 'shared/before_login_header' %>
       <% end %>
-      <div class="flex-grow">
+      <%= render 'shared/flash_message' %>
         <%= yield %>
-      </div>
       <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= message_type == 'success' || message_type == 'notice' ? 'bg-green' : 'bg-red' %>">
+    <%= content_tag :p, message, class: "p-3 text-base md:text-lg" %>
+  </div>
+<% end %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,9 @@ module.exports = {
       'beige': '#EDDDC5',
       'mint': '#94D0BF',
       'yellow': '#FFE567',
-      'gray': '#f3f4f6'
+      'gray': '#f3f4f6',
+      'green': '#86efac',
+      'red': '#fca5a5'
     },
   },
   plugins: [require("daisyui")],


### PR DESCRIPTION
## 関連issue
Closes #56 

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- フラッシュメッセージの設定

## 実装内容
- ユーザーが以下の動作を行った時、フラッシュメッセージが出るように設定
  - 新規登録時
  - ログイン
  - 使用した化粧品登録
  - 使用した化粧品の編集
  - 使用した化粧品の削除
  - マイページの編集

## 備考
- i18nは別のissueで行うつもりのため、新規登録時とログイン時以外はそのまま日本語で書いている