### PR TITLE
デイリー入力削除機能の作成

### DIFF
--- a/app/controllers/cosmetics_controller.rb
+++ b/app/controllers/cosmetics_controller.rb
@@ -3,6 +3,7 @@ class CosmeticsController < ApplicationController
 
   def index
     @cosmetics = Cosmetic.includes(:category, :brand)
+    @user_mycosmetics = current_user.mycosmetics.pluck(:cosmetic_id)
   end
 
   def show

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -1,6 +1,6 @@
 class DailyReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_daily_report, only: [ :show, :edit, :update ]
+  before_action :set_daily_report, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @daily_reports = DailyReport.includes(:user).where(user: current_user)
@@ -42,6 +42,11 @@ class DailyReportsController < ApplicationController
       flash.now[:danger] = "デイリー入力の更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @daily_report.destroy!
+    redirect_to daily_reports_path, success: "カレンダーから削除しました"
   end
 
   private

--- a/app/models/daily_report.rb
+++ b/app/models/daily_report.rb
@@ -1,6 +1,6 @@
 class DailyReport < ApplicationRecord
   belongs_to :user
-  has_many :daily_report_cosmetics
+  has_many :daily_report_cosmetics, dependent: :destroy
   has_many :mycosmetics, through: :daily_report_cosmetics
 
   enum health: {

--- a/app/views/cosmetics/_cosmetic.html.erb
+++ b/app/views/cosmetics/_cosmetic.html.erb
@@ -18,7 +18,9 @@
           <%= cosmetic.amount %>
         </p>
         <div class="card-actions justify-end">
+        <% if !@user_mycosmetics.include?(cosmetic.id) %>
           <%= link_to "登録", new_mycosmetic_path(cosmetic_id: cosmetic.id), class:"btn bg-beige btn-outline" %>
+          <% end %>
           <%= render 'favorite_buttons', { cosmetic: cosmetic } %>
         </div>
       </div>

--- a/app/views/daily_reports/show.html.erb
+++ b/app/views/daily_reports/show.html.erb
@@ -36,7 +36,7 @@
 
       <div class="flex justify-center gap-6 pt-10">
         <%= link_to "編集", edit_daily_report_path(@daily_report), class: "btn bg-beige btn-outline "%>
-        <%= link_to "削除", "#", class: "btn bg-beige btn-outline"%>
+        <%= link_to "削除", daily_report_path(@daily_report), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "btn bg-beige btn-outline"%>
       </div>
     </div>
   </div>

--- a/app/views/mycosmetics/index.html.erb
+++ b/app/views/mycosmetics/index.html.erb
@@ -29,7 +29,7 @@
         </div>
         <div class="card-body w-[calc(100%_-_192px)]">
           <h2 class="card-title">
-            <%= mycosmetic.cosmetic.product_name %>
+          <%= link_to mycosmetic.cosmetic.product_name, cosmetic_path(mycosmetic.cosmetic) %>
           </h2>
           <p>
             <%= link_to mycosmetic.cosmetic.category.name, '#' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
   end
   resources :mycosmetics, only: %i[new create index edit update destroy]
   resources :profiles, only: %i[index update]
-  resources :daily_reports, only: %i[new create index show edit update]
+  resources :daily_reports, only: %i[new create index show edit update destroy]
 end


### PR DESCRIPTION
## 関連issue
Closes #42 

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- デイリー入力削除機能の作成

## 実装内容
- daily_reportsコントローラにdestroyアクションを追加
- ルーティングを追加
- 削除ボタンを押した時に「投稿を削除しますか？」というダイアログが表示される
- 削除した後はindexに遷移される

## 備考
- コスメ一覧でマイコスメに登録している化粧品の登録ボタンを表示させないように変更
- マイコスメ一覧の化粧品名から詳細ページに遷移できる